### PR TITLE
Update of the EUR balance ensemble matrix

### DIFF
--- a/CMIP6_downscaling_plans.csv
+++ b/CMIP6_downscaling_plans.csv
@@ -285,18 +285,18 @@ EUR-12,BCCR-UCAN,S. Sobolowski / O. Gokturk / J. Fernandez / J. Milovac,WRF451Q,
 EUR-12,BCCR-UCAN,S. Sobolowski / O. Gokturk / J. Fernandez / J. Milovac,WRF451Q,NorESM2-MM,r1i1p1f1,ssp370,completed,2025-12,#EURbalanced #CORDEX-CORE
 EUR-12,CESAM-UA,D. Carvalho,WRF451Q,ERA5,,evaluation,completed,2025-06,#RCMintvar Realization r2
 EUR-12,CESAM-UA,D. Carvalho,WRF451Q,MPI-ESM1-2-HR,r1i1p1f1,ssp585,running,2026-12,#ManySSP
-EUR-12,CLMcom-Hereon,B. Geyer,CCLM6-0-1,ERA5,,evaluation,completed,2024-12,#ManyGCM #EURcoupled
-EUR-12,CLMcom-LIST,M. Sulis,CCLM6-0-1,MPI-ESM1-2-HR,r1i1p1f1,historical,completed,2025-12,#ManyGCM #EURcoupled
-EUR-12,CLMcom-LIST,M. Sulis,CCLM6-0-1,MPI-ESM1-2-HR,r1i1p1f1,ssp126,completed,2025-12,#ManyGCM #EURcoupled
-EUR-12,CLMcom-LIST,M. Sulis,CCLM6-0-1,MPI-ESM1-2-HR,r1i1p1f1,ssp370,completed,2025-12,#ManyGCM #EURcoupled
+EUR-12,CLMcom-Hereon,B. Geyer,CCLM6-0-1,ERA5,,evaluation,completed,2024-12,#ManyGCM #EURcoupled #EURbalanced
+EUR-12,CLMcom-LIST,M. Sulis,CCLM6-0-1,MPI-ESM1-2-HR,r1i1p1f1,historical,completed,2025-12,#ManyGCM #EURcoupled #EURbalanced
+EUR-12,CLMcom-LIST,M. Sulis,CCLM6-0-1,MPI-ESM1-2-HR,r1i1p1f1,ssp126,completed,2025-12,#ManyGCM #EURcoupled #EURbalanced
+EUR-12,CLMcom-LIST,M. Sulis,CCLM6-0-1,MPI-ESM1-2-HR,r1i1p1f1,ssp370,completed,2025-12,#ManyGCM #EURcoupled #EURbalanced
 EUR-12,CLMcom-KIT,H. Feldmann,CCLM6-0-1,EC-Earth3-Veg,r1i1p1f1,historical,completed,2025-01,#ManyGCM #Nukleus
 EUR-12,CLMcom-KIT,H. Feldmann,CCLM6-0-1,EC-Earth3-Veg,r1i1p1f1,ssp126,completed,2025-03,#ManyGCM #Nukleus
 EUR-12,CLMcom-KIT,H. Feldmann,CCLM6-0-1,EC-Earth3-Veg,r1i1p1f1,ssp370,completed,2025-03,#ManyGCM #Nukleus
-EUR-12,CLMcom-KIT,H. Feldmann,CCLM6-0-1,MIROC6,r1i1p1f1,historical,completed,2025-01,#ManyGCM #Nukleus
-EUR-12,CLMcom-KIT,H. Feldmann,CCLM6-0-1,MIROC6,r1i1p1f1,ssp370,completed,2025-03,#ManyGCM #Nukleus
-EUR-12,CLMcom-CMCC,M. Raffa / M. Adinolfi / A. Campanale,CCLM6-0-1,CMCC-CM2-SR5,r1i1p1f1,historical,completed,2024-12, #ManyGCM
-EUR-12,CLMcom-CMCC,M. Raffa / M. Adinolfi / A. Campanale,CCLM6-0-1,CMCC-CM2-SR5,r1i1p1f1,ssp126,completed,2024-12, #ManyGCM
-EUR-12,CLMcom-CMCC,M. Raffa / M. Adinolfi / A. Campanale,CCLM6-0-1,CMCC-CM2-SR5,r1i1p1f1,ssp370,completed,2024-12, #ManyGCM
+EUR-12,CLMcom-KIT,H. Feldmann,CCLM6-0-1,MIROC6,r1i1p1f1,historical,completed,2025-01,#ManyGCM #Nukleus #EURbalanced
+EUR-12,CLMcom-KIT,H. Feldmann,CCLM6-0-1,MIROC6,r1i1p1f1,ssp370,completed,2025-03,#ManyGCM #Nukleus #EURbalanced
+EUR-12,CLMcom-CMCC,M. Raffa / M. Adinolfi / A. Campanale,CCLM6-0-1,CMCC-CM2-SR5,r1i1p1f1,historical,completed,2024-12, #ManyGCM #EURbalanced
+EUR-12,CLMcom-CMCC,M. Raffa / M. Adinolfi / A. Campanale,CCLM6-0-1,CMCC-CM2-SR5,r1i1p1f1,ssp126,completed,2024-12, #ManyGCM #EURbalanced
+EUR-12,CLMcom-CMCC,M. Raffa / M. Adinolfi / A. Campanale,CCLM6-0-1,CMCC-CM2-SR5,r1i1p1f1,ssp370,completed,2024-12, #ManyGCM #EURbalanced
 EUR-12,CLMcom-IMWM,A. Jaczewski,CCLM6-0-1,NorESM2-MM,r1i1p1f1,historical,planned,2025-03,#ManyGCM
 EUR-12,CLMcom-IMWM,A. Jaczewski,CCLM6-0-1,NorESM2-MM,r1i1p1f1,ssp126,planned,2025-03,#ManyGCM
 EUR-12,CLMcom-IMWM,A. Jaczewski,CCLM6-0-1,NorESM2-MM,r1i1p1f1,ssp370,planned,2025-03,#ManyGCM
@@ -308,7 +308,7 @@ EUR-12,CLMcom-FZJ,K. Goergen,TSMP1-140-E,ERA5,,evaluation,completed,2025-04,#EUR
 EUR-12,CLMcom-FZJ,K. Goergen,TSMP1-140-E,MPI-ESM1-2-HR,r1i1p1f1,historical,completed,2025-03,#EURcoupled
 EUR-12,CLMcom-FZJ,K. Goergen,TSMP1-140-E,MPI-ESM1-2-HR,r1i1p1f1,ssp126,completed,2025-09,#EURcoupled
 EUR-12,CLMcom-FZJ,K. Goergen,TSMP1-140-E,MPI-ESM1-2-HR,r1i1p1f1,ssp370,completed,2025-09,#EURcoupled
-EUR-12,CLMcom-FZJ,K. Goergen,CCLM6-0-1,MIROC6,r1i1p1f1,ssp126,planned,2026-03,#ManyGCM
+EUR-12,CLMcom-FZJ,K. Goergen,CCLM6-0-1,MIROC6,r1i1p1f1,ssp126,planned,2026-03,#ManyGCM #EURbalanced
 EUR-12,CLMcom-Hereon,H. Hagemann,GCOAST-AHOI1-1,ERA5,,evaluation,completed,2024-08,#EURcoupled ORAS5 BC in the ocean
 EUR-12,CLMcom-Hereon,H. Hagemann,GCOAST-AHOI1-1,MPI-ESM1-2-HR,r1i1p1f1,historical,completed,2024-07,#EURcoupled
 EUR-12,CLMcom-Hereon,H. Hagemann,GCOAST-AHOI1-1,MPI-ESM1-2-HR,r1i1p1f1,ssp370,completed,2024-12,#EURcoupled


### PR DESCRIPTION
This is a proposal raised by @csteger during the recent EURO-CORDEX GA 2026 to include CCLM in the balanced matrix experiment. The matrix would look like this:

<img width="1015" height="377" alt="image" src="https://github.com/user-attachments/assets/54a9b598-7ba2-4d3c-9b6c-18675e85e754" />

All other simulations remain the same, just the CCLM6-0-1 ones were added. The only problem I see is that the CCLM driving GCMs are a subset of those for ICON. On the other hand, the MPI-ESM>ICON simulation is contributing to unbalance the ensemble, by having both the GCM and RCM an excess in the matrix.

The building rule was to have at least 3 GCMs per RCM and at least 4 RCMs per GCM. This minimum (3,4) cannot be achieved, but this MPI>ICON simulation is enlarging unnecessarily the matrix. By dropping it, MPI would have 4 nested RCMs, ICON is nested to 3 GCMs and CCLM and ICON would have two independent sets of driving GCMs. I understand that this MPI>ICON simulation is a flagship simulation for the UDAG project, so let me know what do you think.

On the other hand, and in principle unrelated to this, the CNRM-ESM2-1 GCM is at risk of not having the minimum number (4) of RCMs nested into it. RegCM5 simulations at CUNI are still planned (@micval could you provide an update?). The MPI>ICON simulation could be replaced by the CNRM>ICON one to make sure we meet the balance design. In this case, the HCLIM set (@gnikulin ) would be a subset of those driving ICON.

@guillaumeevin @sam-somot @stefan-sobolowski what do you think?