### PR TITLE
Update ESGF page

### DIFF
--- a/CORDEX_CMIP6_data_servers.py
+++ b/CORDEX_CMIP6_data_servers.py
@@ -69,14 +69,18 @@ def generate_non_esgf_table(servers):
 
 
 def generate_esgf_table(servers):
-    sims = pd.read_csv('CMIP6_downscaling_plans.csv')
-    sims = assign_node_to_sim(sims, servers)
+    plans = pd.read_csv('CMIP6_downscaling_plans.csv')
+    plans = assign_node_to_sim(plans, servers)
+    hostable = plans[plans.node_index != -1]
+
+    published = pd.read_csv('CMIP6_downscaling_published.csv')
+    node_urls = [s['url'] for s in servers]
+    published['node_index'] = published.data_node.apply(node_urls.index)
 
     nodes = pd.DataFrame(servers).drop(columns=['simulations'])
 
-    hosted = sims[sims.node_index != -1]
-    nodes['sim_pub'] = hosted[hosted.status == 'published'].groupby('node_index').domain_id.count()
-    nodes['sim_tot'] = hosted.groupby('node_index').domain_id.count()
+    nodes['sim_pub'] = published.groupby('node_index').domain_id.count()
+    nodes['sim_tot'] = hostable.groupby('node_index').domain_id.count()
     nodes['sim_pub'] = nodes['sim_pub'].fillna(0)
     nodes['sim_tot'] = nodes['sim_tot'].fillna(0)
     nodes['sim_count'] = nodes.apply(lambda row: f"{row.sim_pub:.0f} ({row.sim_tot:.0f} planned)", axis=1)
@@ -85,7 +89,7 @@ def generate_esgf_table(servers):
     nodes = nodes[['name', 'status', 'comment', 'index', 'accepting_requests', 'volume', 'sim_count', 'url']]
 
     # CSV with non-published simulations, for power users only.
-    orphans = sims[sims.node_index == -1].drop(columns=['node_name', 'node_url', 'node_index'])
+    orphans = plans[plans.node_index == -1].drop(columns=['node_name', 'node_url', 'node_index'])
     orphans.to_csv('docs/CORDEX_CMIP6_orphan_simulations.csv', index=False)
     # Create temporary CSV for processing and ensure cleanup
     with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as tmp_file:
@@ -131,7 +135,6 @@ def generate_esgf_table(servers):
             title=title, 
             intro=intro, 
             rename_fields=rename_fields,
-            column_as_link='url',
         )
 
         print(f"Generated {htmlout} from Yaml file.")

--- a/CORDEX_CMIP6_data_servers.yaml
+++ b/CORDEX_CMIP6_data_servers.yaml
@@ -14,7 +14,7 @@
 #
 # To add information about hosting on the ESGF, create an entry with the following fields:
 #  - name : Data node name (for example the hosting institution)
-#  - url : URL to the data node, if available.
+#  - url : URL to the data node, if available, same as entered in `CMIP6_simulations.published.csv'
 #  - index : The name of the ESGF index this node is (will be) publishing to : "west" (LLNI) or "east" (CEDA).
 #  - status : "planned" or "unmigrated" (up, but not yet ESGF-NG), "published" (up and ESGF-NG), status of the node.
 #  - volume : The estimated volume in TiB of data the node will hold (CORDEX-CMIP6 and CORDEX-CMIP7-AFT)
@@ -38,9 +38,9 @@ esgf:
       - institution_id: [ICTP, ENEA, CMCC, CLMcom-CMCC]
 
   - name: Ouranos
-    url: https://esgf.ouranos.ca/
+    url: esgf.ouranos.ca
     index: west
-    status: planned
+    status: published
     volume: 650
     comment: Private data node hosted at Ouranos for simulations produced there.
     accepting_requests: False
@@ -48,9 +48,9 @@ esgf:
       - institution_id: OURANOS
 
   - name: IPSL
-    url: https://esgf.ipsl.fr/
+    url: esgf.ipsl.fr
     index: east
-    status: unmigrated
+    status: published
     volume: null
     comment: Also has some CORDEX-CMIP5 data. Most space is reserved for specific groups, but some is open for additionnal groups.
     accepting_requests: True
@@ -67,9 +67,9 @@ esgf:
         institution_id: IRD-MF
 
   - name: DWD
-    url : https://esgf-data.dwd.de/
+    url : esgf1.dkrz.de
     index: east
-    status: unmigrated
+    status: published
     volume: 1915
     comment : Subnode of DKRZ. Only open to certain groups, limited storage.
     accepting_requests: False
@@ -90,9 +90,9 @@ esgf:
       - institution_id: [DMI, UU-IMAU]
 
   - name: CCCma
-    url: http://crd-esgf-drc.ec.gc.ca/
+    url: crd-esgf-drc.ec.gc.ca
     index: west
-    status: unmigrated
+    status: published
     volume: 1800
     comment: Only for CCCma data.
     accepting_requests: False
@@ -113,7 +113,7 @@ esgf:
 
 
   - name: RU-CORE
-    url: https://esg-dn1.ru.ac.th
+    url: esg-dn1.ru.ac.th
     index: null
     status: unmigrated
     volume: null
@@ -124,7 +124,7 @@ esgf:
         institution_id: [UMT, UKM-UMT, MO, HKO, RU-CORE, USTH-HUS-IMHEN, USTH, BMKG, CCRC, CSIRO]  
 
   - name: LIU
-    url: https://esg-dn1.nsc.liu.se/projects/esgf-liu
+    url: esg-dn1.nsc.liu.se/projects/esgf-liu
     index: east
     status: unmigrated
     volume: null

--- a/docs/CORDEX_CMIP6_esgf_nodes.html
+++ b/docs/CORDEX_CMIP6_esgf_nodes.html
@@ -105,37 +105,37 @@ span.ESD {color: #ca6f1e; font-weight: bold}
             <td></td>
             <td>2000.0</td>
             <td>0 (63 planned)</td>
-            <td><a href=""></a></td>
+            <td></td>
         </tr>
         <tr>
             <td>Ouranos</td>
-            <td><span class="planned">planned</span></td>
+            <td><span class="published">published</span></td>
             <td>Private data node hosted at Ouranos for simulations produced there.</td>
             <td>west</td>
             <td>False</td>
             <td>650.0</td>
-            <td>0 (26 planned)</td>
-            <td><a href="https://esgf.ouranos.ca/">https://esgf.ouranos.ca/</a></td>
+            <td>26 (26 planned)</td>
+            <td>esgf.ouranos.ca</td>
         </tr>
         <tr>
             <td>IPSL</td>
-            <td><span class="unmigrated">unmigrated</span></td>
+            <td><span class="published">published</span></td>
             <td>Also has some CORDEX-CMIP5 data. Most space is reserved for specific groups, but some is open for additionnal groups.</td>
             <td>east</td>
             <td>True</td>
             <td></td>
-            <td>0 (32 planned)</td>
-            <td><a href="https://esgf.ipsl.fr/">https://esgf.ipsl.fr/</a></td>
+            <td>17 (32 planned)</td>
+            <td>esgf.ipsl.fr</td>
         </tr>
         <tr>
             <td>DWD</td>
-            <td><span class="unmigrated">unmigrated</span></td>
+            <td><span class="published">published</span></td>
             <td>Subnode of DKRZ. Only open to certain groups, limited storage.</td>
             <td>east</td>
             <td>False</td>
             <td>1915.0</td>
-            <td>0 (59 planned)</td>
-            <td><a href="https://esgf-data.dwd.de/">https://esgf-data.dwd.de/</a></td>
+            <td>31 (59 planned)</td>
+            <td>esgf1.dkrz.de</td>
         </tr>
         <tr>
             <td>DMI</td>
@@ -145,17 +145,17 @@ span.ESD {color: #ca6f1e; font-weight: bold}
             <td>False</td>
             <td>163.0</td>
             <td>0 (15 planned)</td>
-            <td><a href="cordexesg.dmi.dk">cordexesg.dmi.dk</a></td>
+            <td>cordexesg.dmi.dk</td>
         </tr>
         <tr>
             <td>CCCma</td>
-            <td><span class="unmigrated">unmigrated</span></td>
+            <td><span class="published">published</span></td>
             <td>Only for CCCma data.</td>
             <td>west</td>
             <td>False</td>
             <td>1800.0</td>
-            <td>0 (85 planned)</td>
-            <td><a href="http://crd-esgf-drc.ec.gc.ca/">http://crd-esgf-drc.ec.gc.ca/</a></td>
+            <td>1 (85 planned)</td>
+            <td>crd-esgf-drc.ec.gc.ca</td>
         </tr>
         <tr>
             <td>NCI</td>
@@ -165,7 +165,7 @@ span.ESD {color: #ca6f1e; font-weight: bold}
             <td>True</td>
             <td></td>
             <td>0 (133 planned)</td>
-            <td><a href="esgf.nci.org.au">esgf.nci.org.au</a></td>
+            <td>esgf.nci.org.au</td>
         </tr>
         <tr>
             <td>RU-CORE</td>
@@ -175,7 +175,7 @@ span.ESD {color: #ca6f1e; font-weight: bold}
             <td></td>
             <td></td>
             <td>0 (65 planned)</td>
-            <td><a href="https://esg-dn1.ru.ac.th">https://esg-dn1.ru.ac.th</a></td>
+            <td>esg-dn1.ru.ac.th</td>
         </tr>
         <tr>
             <td>LIU</td>
@@ -185,7 +185,7 @@ span.ESD {color: #ca6f1e; font-weight: bold}
             <td></td>
             <td></td>
             <td>0 (19 planned)</td>
-            <td><a href="https://esg-dn1.nsc.liu.se/projects/esgf-liu">https://esg-dn1.nsc.liu.se/projects/esgf-liu</a></td>
+            <td>esg-dn1.nsc.liu.se/projects/esgf-liu</td>
         </tr>
         <tr>
             <td>CEDA</td>
@@ -195,7 +195,7 @@ span.ESD {color: #ca6f1e; font-weight: bold}
             <td></td>
             <td></td>
             <td>0 (51 planned)</td>
-            <td><a href=""></a></td>
+            <td></td>
         </tr>
         <tr>
             <td>Norwegian</td>
@@ -205,7 +205,7 @@ span.ESD {color: #ca6f1e; font-weight: bold}
             <td></td>
             <td></td>
             <td>0 (5 planned)</td>
-            <td><a href=""></a></td>
+            <td></td>
         </tr>
         <tr>
             <td>IITM</td>
@@ -215,7 +215,7 @@ span.ESD {color: #ca6f1e; font-weight: bold}
             <td></td>
             <td></td>
             <td>0 (10 planned)</td>
-            <td><a href="esg-cccr.tropmet.res.in">esg-cccr.tropmet.res.in</a></td>
+            <td>esg-cccr.tropmet.res.in</td>
         </tr>
         <tr>
             <td>ORNL</td>
@@ -225,7 +225,7 @@ span.ESD {color: #ca6f1e; font-weight: bold}
             <td>True</td>
             <td>1500.0</td>
             <td>0 (34 planned)</td>
-            <td><a href=""></a></td>
+            <td></td>
         </tr>
 
     </tbody>


### PR DESCRIPTION
- Uses the new "published" csv to count published datasets on the ESGF nodes page.
- Update the ESGF server status to published for the ones appearing in the "published" csv (to be done by hand, not automated).
- Updates the ESGF urls to only keep the server part, not a link anymore in the table. ESGF nodes usually don't have a homepage, no use having a link.
- Update the DKRZ node address with what I can see published in ESGF.